### PR TITLE
Altered test script to not generate source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build",
+    "build": "ng build --source-map=false --watch=false",
     "watch": "ng build --watch --configuration development",
     "test": "ng test --source-map=false --watch=false --browsers=ChromeHeadlessPuppeteer"
   },


### PR DESCRIPTION
Should speed up our pipeline somewhat. Not sure if build should also not generate source maps, as far I can tell, source maps are really only used for testing. This should be merged by the end of the sprint at least, so not very important at the moment.